### PR TITLE
Simplify implementation of CallbackQueue::callOne()

### DIFF
--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -228,13 +228,39 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
       return Disabled;
     }
 
-    ros::SteadyTime start_time(ros::SteadyTime::now());
+    boost::chrono::steady_clock::time_point wait_until =
+        boost::chrono::steady_clock::now() + boost::chrono::nanoseconds(timeout.toNSec());
+    while (!cb_info.callback) {
+      D_CallbackInfo::iterator it = callbacks_.begin();
+      for (; it != callbacks_.end();)
+      {
+        CallbackInfo& info = *it;
 
-    if (callbacks_.empty())
-    {
+        if (info.marked_for_removal)
+        {
+          it = callbacks_.erase(it);
+          continue;
+        }
+
+        if (info.callback->ready())
+        {
+          cb_info = info;
+          it = callbacks_.erase(it);
+          break;
+        }
+
+        ++it;
+      }
+
+      // Found a ready callback?
+      if (cb_info.callback) {
+        break;
+      }
+
+      boost::cv_status wait_status = boost::cv_status::no_timeout;
       if (!timeout.isZero())
       {
-        condition_.wait_for(lock, boost::chrono::nanoseconds(timeout.toNSec()));
+        wait_status = condition_.wait_until(lock, wait_until);
       }
 
       if (callbacks_.empty())
@@ -246,43 +272,11 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
       {
         return Disabled;
       }
-    }
 
-    D_CallbackInfo::iterator it = callbacks_.begin();
-    for (; it != callbacks_.end();)
-    {
-      CallbackInfo& info = *it;
-
-      if (info.marked_for_removal)
+      if (wait_status == boost::cv_status::timeout)
       {
-        it = callbacks_.erase(it);
-        continue;
+        return TryAgain;
       }
-
-      if (info.callback->ready())
-      {
-        cb_info = info;
-        it = callbacks_.erase(it);
-        break;
-      }
-
-      ++it;
-    }
-
-    if (!cb_info.callback)
-    {
-      // do not spend more than `timeout` seconds in the callback; we already waited for some time when waiting for
-      // nonempty queue
-      ros::SteadyTime now(ros::SteadyTime::now());
-      ros::WallDuration time_spent = now - start_time;
-      ros::WallDuration time_to_wait = timeout - time_spent;
-
-      if (time_to_wait.toNSec() > 0)
-      {
-        condition_.wait_for(lock, boost::chrono::nanoseconds(time_to_wait.toNSec()));
-      }
-
-      return TryAgain;
     }
 
     ++calling_;

--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -257,7 +257,7 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
         break;
       }
 
-      boost::cv_status wait_status = boost::cv_status::no_timeout;
+      boost::cv_status wait_status = boost::cv_status::timeout;
       if (!timeout.isZero())
       {
         wait_status = condition_.wait_until(lock, wait_until);


### PR DESCRIPTION
I was working on an ABI-compatible solution for https://github.com/ros/ros_comm/issues/1545 because we were also affected by this problem. Only afterwards I found your PR https://github.com/ros/ros_comm/pull/1684 based on what @peci1 suggested in https://github.com/ros/ros_comm/pull/1608. I came up with a similar solution and merged it at the end. Maybe it would be good to explicitly reference https://github.com/ros/ros_comm/pull/1684 in https://github.com/ros/ros_comm/pull/1608 and close the latter?

I suggest to replace the duplicate `wait_for()` call in `CallbackQueue::callOne()` with a loop and a single call to `wait_until()`. There is also no need to calculate the remaining duration of the timeout explicitly.

The behavior is slightly different: `callOne(timeout)` only returns `TryAgain` if the timeout expired and none of the callbacks in the queue was ready. If one of the callbacks gets ready within the given timeout, it will be called without returning to the caller. That does not make a significant difference at the end if the caller invokes `callOne()` again immediately like the spinner does.

~~I needed the `BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC` to be defined because I am currently testing with Boost 1.58 in Ubuntu 16.04 (custom melodic build) (https://github.com/ros/ros_comm/pull/1684#discussion_r294893014). If it gets removed, the `BOOST_VERSION` check in line 44-50 should be removed, too.~~

I can confirm that when building in debug mode without compiler optimizations, the unit test fails without also applying https://github.com/ros/ros_comm/pull/1651.